### PR TITLE
Add a component to display business suggestions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,9 @@
     "paper-input": "PolymerElements/paper-input#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "showdown": "^1.7.1",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.7"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.7",
+    "vaadin-grid": "^3.0.0",
+    "iron-ajax": "PolymerElements/iron-ajax#^2.0.2"
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.7"

--- a/src/my-view1.html
+++ b/src/my-view1.html
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="ryr-rack-request-form.html" />
 <link rel="import" href="ryr-email-templatizer.html" />
 <link rel="import" href="ryr-preview.html" />
+<link rel="import" href="ryr-suggestion-list.html" />
 
 <dom-module id="my-view1">
   <template>
@@ -37,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .rack-request {
         display: flex;
       }
-  </style>
+    </style>
 
     <div class="card">
       <div class="circle">1</div>
@@ -49,6 +50,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <granite-clipboard text="[[md]]">
           <paper-icon-button icon="content-copy" title="copy"></paper-icon-button>
         </granite-clipboard>
+      </div>
+      <div>
+        <ryr-suggestion-list></ryr-suggestion-list>
       </div>
     </div>
   </template>

--- a/src/ryr-suggestion-list.html
+++ b/src/ryr-suggestion-list.html
@@ -1,0 +1,61 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/vaadin-grid/all-imports.html">
+<link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
+
+<dom-module id="ryr-suggestion-list">
+  <template>
+    <!-- TODO(rémyg): Find a way to provide the URL via environment variables -->
+    <iron-ajax
+    auto
+    url="http://localhost:18000/places/"
+    handle-as="json"
+    last-response="{{response}}"
+    jsonPrefix="results"></iron-ajax>
+    <!-- <vaadin-grid id="grid" active-item="{{activeItem}}" items='[{"name":"100-214 W N Loop Blvd","place_id":"ChIJScAAmmvKRIYRn42comEgS20"}, {"name":"Epoch Coffee - NorthLoop","place_id":"ChIJG-gJw2vKRIYROWi2uwOp8QE"}, {"name":"Blue Velvet","place_id":"ChIJBzPI6WvKRIYRO059hPJZndU"}, {"name":"Breakaway Records","place_id":"ChIJl97swWvKRIYR04M3oxYPG-Y"}, {"name":"The Center Spot","place_id":"ChIJb-iQwWvKRIYREcuAEGb-Brw"}, {"name":"Waller Creek","place_id":"ChIJzSjl3GvKRIYRk3hfNfLuAL4"}, {"name":"Austin","place_id":"ChIJLwPMoJm1RIYRetVp1EtGm10"}]'> -->
+    <vaadin-grid id="grid" active-item="{{activeItem}}" items="[[response.results]]" size="10">
+      <vaadin-grid-column width="50px" flex-grow="0">
+        <template class="header">#</template>
+  <template>[[index]]</template>
+  </vaadin-grid-column>
+  <vaadin-grid-column>
+    <template class="header">Name</template>
+    <template>[[item.name]]</template>
+  </vaadin-grid-column>
+  <vaadin-grid-column>
+    <template class="header">Place ID</template>
+    <template>[[item.place_id]]</template>
+  </vaadin-grid-column>
+  </vaadin-grid>
+  </template>
+  <!-- Web component class. -->
+  <script>
+    /**
+     * `ryr-suggestion-list`
+     * Request a rack
+     *
+     * @customElement
+     * @polymer
+     * @demo demo/index.html
+     */
+    class RyrSuggestionList extends Polymer.Element {
+      static get is() {
+        return 'ryr-suggestion-list';
+      }
+
+      static get properties() {
+        return {
+          activeItem: {
+            observer: '_activeItemChanged'
+          }
+        };
+      }
+
+      _activeItemChanged(item) {
+        this.$.grid.selectedItems = item ? [item] : [];
+      }
+
+    }
+
+    window.customElements.define(RyrSuggestionList.is, RyrSuggestionList);
+  </script>
+</dom-module>


### PR DESCRIPTION
Description
-----------

This patch adds a new component that displays a list of business
suggestions based on GPS coordinates.

Motivation and Context
----------------------

When retrieving information from Google maps, a list of places located
near by is returned. Depending on the accuracy of the coordinates or
whether there are multiple businesses in the same building, we cannot
accurately determine which business the user wanted to specify.
Therefore the list of available possibilities is displayed in a
`vaadin-grid` component and the user can select the most appropriate
one.

How Has This Been Tested?
----------------------------

Manually using Chrome and the developer tools.

Types of changes
----------------

- New feature (non-breaking change which adds functionality)

Checklist:
----------

<!-- Go over all the following points, and put an `x` in all the boxes
that apply. If you're unsure about any of these, don't hesitate to
ask. We're here to help! -->

-  [] I have updated the documentation accordingly.
-  [] I have written unit tests